### PR TITLE
keep accepting and negotiating connections until we have 16 ready and queued up

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -63,12 +63,7 @@ func (l *listener) handleIncoming() {
 	}()
 
 	var catcher tec.TempErrCatcher
-	for {
-		// no need to wait on the context.
-		// Close will drain the incoming channel which will cause the
-		// threshold to drop.
-		l.threshold.Wait()
-
+	for l.ctx.Err() == nil {
 		maconn, err := l.Listener.Accept()
 		if err != nil {
 			if catcher.IsTemporary(err) {
@@ -121,6 +116,10 @@ func (l *listener) handleIncoming() {
 				conn.Close()
 			}
 		}()
+
+		// The go routine above calls Release when the context is
+		// canceled so there's no need to wait on it here.
+		l.threshold.Wait()
 	}
 }
 

--- a/threshold.go
+++ b/threshold.go
@@ -20,12 +20,6 @@ type threshold struct {
 	threshold int
 }
 
-func (t *threshold) Count() int {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	return t.count
-}
-
 // Acquire increments the counter. It will not block.
 func (t *threshold) Acquire() {
 	t.mu.Lock()

--- a/threshold.go
+++ b/threshold.go
@@ -1,0 +1,56 @@
+package stream
+
+import (
+	"sync"
+)
+
+func newThreshold(cutoff int) *threshold {
+	t := &threshold{
+		threshold: cutoff,
+	}
+	t.cond.L = &t.mu
+	return t
+}
+
+type threshold struct {
+	mu   sync.Mutex
+	cond sync.Cond
+
+	count     int
+	threshold int
+}
+
+func (t *threshold) Count() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.count
+}
+
+// Acquire increments the counter. It will not block.
+func (t *threshold) Acquire() {
+	t.mu.Lock()
+	t.count++
+	t.mu.Unlock()
+}
+
+// Release decrements the counter.
+func (t *threshold) Release() {
+	t.mu.Lock()
+	if t.count == 0 {
+		panic("negative count")
+	}
+	if t.threshold == t.count {
+		t.cond.Broadcast()
+	}
+	t.count--
+	t.mu.Unlock()
+}
+
+// Wait waits for the counter to drop below the threshold
+func (t *threshold) Wait() {
+	t.mu.Lock()
+	for t.count > t.threshold {
+		t.cond.Wait()
+	}
+	t.mu.Unlock()
+}

--- a/upgrader.go
+++ b/upgrader.go
@@ -19,6 +19,9 @@ import (
 // without specifying a peer ID.
 var ErrNilPeer = errors.New("nil peer")
 
+// AcceptQueueLength is the number of connections to fully setup before not accepting any new connections
+var AcceptQueueLength = 16
+
 // Upgrader is a multistream upgrader that can upgrade an underlying connection
 // to a full transport connection (secure and multiplexed).
 type Upgrader struct {
@@ -35,7 +38,7 @@ func (u *Upgrader) UpgradeListener(t transport.Transport, list manet.Listener) t
 		Listener:  list,
 		upgrader:  u,
 		transport: t,
-		ticket:    make(chan struct{}),
+		threshold: newThreshold(AcceptQueueLength),
 		incoming:  make(chan transport.Conn),
 		cancel:    cancel,
 		ctx:       ctx,


### PR DESCRIPTION
Otherwise, we'll have an annoying saw-tooth pattern where we'll accept a bunch of connections, set them up in parallel, and then wait until we pass them all back up to the swarm before accepting any more.

This commit allows us to queue up 16 ready connections before ceasing to accept any new connections. We'll still probably have a saw-tooth pattern under heavy load but it should be less pronounced (and we can improve the situation by upping the queue size.

@marten-seemann thoughts?